### PR TITLE
Enable CORS

### DIFF
--- a/school_management/settings.py
+++ b/school_management/settings.py
@@ -57,7 +57,6 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'school_management.urls'
-CORS_ORIGIN_ALLOW_ALL = True
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Without Cross origin resource sharing, we won't be able to access the API from a different domain